### PR TITLE
feat: add tag management and per-tag totals

### DIFF
--- a/app.py
+++ b/app.py
@@ -819,7 +819,7 @@ document.getElementById('fin_manual').addEventListener('change', updateDuracion)
                              JOIN tags t ON t.id = rt.tag_id
                              WHERE r.fecha = ?
                              GROUP BY t.id''', (f,))
-            tags_tot = list(cur.fetchall())
+            tags_tot = [dict(r) for r in cur.fetchall()]
             cur.execute('''SELECT SUM(duracion) as total FROM registros WHERE fecha=? AND id NOT IN (SELECT registro_id FROM registro_tags)''', (f,))
             row = cur.fetchone()
             sin_tag_total = row['total'] or 0

--- a/static/style.css
+++ b/static/style.css
@@ -297,6 +297,19 @@ details summary {
   flex-wrap: wrap;
 }
 
+.tag {
+  display: inline-block;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.3rem;
+  color: #fff;
+  font-size: 0.75rem;
+  margin-right: 0.25rem;
+}
+
+.tag-selector label {
+  margin-right: 0.5rem;
+}
+
 /* ---------- Calendario semanal ---------- */
 .calendar-controls {
   display: flex;


### PR DESCRIPTION
## Summary
- introduce tag tables and helper utilities
- require selecting tags on entries and support per-tag time totals
- add management page for tags with random colors and max daily minutes

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689bdc1763b4832fbd7ce9d18b97f23a